### PR TITLE
Specify identifier instead of path for plugin

### DIFF
--- a/checks/check-du
+++ b/checks/check-du
@@ -15,13 +15,28 @@ use Bloonix::Plugin;
 
 ###########     Integrate into Bloonix plugin infrastructure.      ############
 
-my $plugin = Bloonix::Plugin->new( version => '0.4' );
-
+my $plugin = Bloonix::Plugin->new( version => '0.5' );
+$plugin->info(
+    join( " ",
+        "This plugin checks the size and inode count of a directory.",
+        "To do this, it requires a cron job to be run.",
+        "The script the cron job should run has been installed to: ",
+        "'/usr/lib/bloonix/etc/cron/cron-du'.",
+        "To setup this plugin to check the size of the /var/www directory",
+        "for example, first choose a unique identifier (eg 'var_www').",
+        "Enter 'var_www' as the value of the Identifier value under",
+        "Check settings.",
+        "Then create a cronjob that has 'var_www' and '/var/www' passed",
+        "to the cron script '/usr/lib/bloonix/etc/cron/cron-du' like this: ",
+        "* */1 * * * /usr/lib/bloonix/etc/cron/cron-du var_www /var/www",
+    )
+);
 $plugin->add_option(
-    name        => 'File',
-    option      => 'file',
-    description => 'File where cron job du command result written',
+    name        => 'Identifier',
+    option      => 'identifier',
+    description => 'Unique identifier for this check',
     value_type  => 'string',
+    example     => 'my_identifier',
     mandatory   => 1,
 );
 
@@ -32,9 +47,9 @@ $plugin->example(
     description =>
         'Warn when directory is greater than 1MB or has more than 100 inodes',
     arguments => [
-        file     => '/var/tmp/du-result-for-some-directory.txt',
-        critical => "inodes:gt:100",
-        warning  => "size:gt:1MB",
+        identifier => 'my_identifier',
+        critical   => "inodes:gt:100",
+        warning    => "size:gt:1MB",
     ]
 );
 
@@ -56,10 +71,11 @@ my $opt = $plugin->parse_options;
 # }
 
 local $/;
-open( my $fh, "<", $opt->{file} )
+my $file = "/var/cache/bloonix/du_$opt->{identifier}.txt";
+open( my $fh, "<", $file )
     or $plugin->exit(
     status  => 'UNKNOWN',
-    message => "Cannot open $opt->{file}: $!."
+    message => "Cannot open $file: $!."
     );
 
 my $output = <$fh>;
@@ -73,7 +89,7 @@ while ( $output =~ /([a-z]++)\s*+:\s*+([0-9]++)/gcm ) {
 unless ( exists $stats->{size} && exists $stats->{inodes} ) {
     $plugin->exit(
         status  => 'UNKNOWN',
-        message => "$opt->{file} must have 'size' and 'inodes' attributes."
+        message => "$file must have 'size' and 'inodes' attributes."
     );
 }
 
@@ -82,7 +98,7 @@ unless ( $stats->{size} =~ /^[0-9]+$/ && $stats->{inodes} =~ /^[0-9]+$/ ) {
     $plugin->exit(
         status => 'UNKNOWN',
         message =>
-            "$opt->{file} 'size' and 'inodes' attribute values must be integers."
+            "$file 'size' and 'inodes' attribute values must be integers."
     );
 }
 

--- a/cronjobs/cron-du
+++ b/cronjobs/cron-du
@@ -3,11 +3,9 @@
 # Check the size of a directory and write the output to a file for bloonix-agent
 
 
-target_dir="$1"
-target_dir_filenamed="$(echo $target_dir | sed -e 's@^/@@g' -e 's@/@_@g' )"
-result_file="/var/lib/bloonix/agent/du_result/${target_dir_filenamed}.json"
-mkdir -p /var/lib/bloonix/agent/du_result
-
+target_dir="$2"
+result_file="/var/cache/bloonix/du_${1}.txt"
+mkdir -p /var/cache/bloonix
 
 if [[ -z $target_dir ]]; then
     echo "Please specify the full path to the directory to check, aborting!"

--- a/plugins/plugin-du
+++ b/plugins/plugin-du
@@ -1,13 +1,13 @@
 plugin {
     id 3000004
-    plugin du.Check
+    plugin DirectorySize.Check
     command check-du
     datatype statistic
-    category System
+    category System,Disk,Filesystem
     netaccess no
     prefer localhost
     description Directory size and inode count check.
-    abstract Read the size and inode count of a directory from a cronjob results file.
+    abstract Checks the size and inode count of a directory.
 }
 
 statistic {


### PR DESCRIPTION
Github issue #27 (Enhance doc for du check).
The result filename is derived from the identifier name by the
cron job script and the agent.